### PR TITLE
feat: Adiciona lista paginada de compras

### DIFF
--- a/frontend/src/components/tables/ComprasTable.jsx
+++ b/frontend/src/components/tables/ComprasTable.jsx
@@ -22,6 +22,8 @@ const ComprasTable = ({
   selectedCompras = new Set(),
   onSelectCompra,
   onSelectAll,
+  pagination,
+  onPageChange,
 }) => {
   const [contextMenu, setContextMenu] = useState(null);
 
@@ -265,6 +267,29 @@ const ComprasTable = ({
           })}
         </tbody>
       </table>
+       {pagination && (
+        <div className="px-6 py-3 flex items-center justify-between border-t border-gray-200 dark:border-gray-700">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            Página <span className="font-medium">{pagination.currentPage}</span> de <span className="font-medium">{pagination.totalPages}</span>
+          </p>
+          <div className="flex-1 flex justify-end space-x-2">
+            <button
+              onClick={() => onPageChange(pagination.currentPage - 1)}
+              disabled={!pagination.hasPrevious || isLoading}
+              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-600"
+            >
+              Anterior
+            </button>
+            <button
+              onClick={() => onPageChange(pagination.currentPage + 1)}
+              disabled={!pagination.hasNext || isLoading}
+              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-600"
+            >
+              Próxima
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Adiciona uma nova seção na página de Compras para exibir uma lista paginada de todas as compras.

- A lista exibe 15 compras por página e inclui controles de paginação.
- A tabela mostra informações chave como Obra, Fornecedor, Data, Valor, Tipo e Status.
- As ações existentes (editar, excluir, ver detalhes, aprovar orçamento) estão disponíveis através de botões e de um menu de contexto de clique-direito nas linhas da tabela.
- A lista é atualizada automaticamente após a criação, edição ou exclusão de uma compra.

---
name: Pull Request
about: Propor uma alteração no código
---

### Descrição

[descreva aqui as alterações propostas]

### Tipo de alteração

- [ ] Correção de bug
- [ ] Novo recurso
- [ ] Melhoria de performance
- [ ] Outro (descreva)

### Como testar

[descreva como testar as alterações]